### PR TITLE
fix: auto update local file provider (#2244)

### DIFF
--- a/component/resource/fetcher.go
+++ b/component/resource/fetcher.go
@@ -183,7 +183,6 @@ func (f *Fetcher[V]) startPullLoop(forceUpdate bool) (err error) {
 	if f.vehicle.Type() == types.File {
 		f.watcher, err = fswatch.NewWatcher(fswatch.Options{
 			Path:     []string{f.vehicle.Path()},
-			Direct:   true,
 			Callback: f.updateCallback,
 		})
 		if err != nil {


### PR DESCRIPTION
`Direct: true` only works when the file will never be removed.
When using ftp it uses a temp file then it's moved to the original file which will trigger 'remove' event instead.